### PR TITLE
Set up cloud dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a personal **dotfiles** collection: setup/bootstrap shell scripts plus
+editor/shell configuration. There is **no server application, build step, or automated
+test suite** — the "product" is the deploy/bootstrap tooling and the config files it symlinks.
+
+### Toolchain
+- **Lint:** `shellcheck` is the shell linter (declared in `Brewfile`; scripts contain
+  `# shellcheck disable=...` directives). Lint everything with:
+  `shellcheck $(find . -name '*.sh' -not -path './.git/*')`
+- The zsh-shebang scripts (`scripts/weekly-update.sh`, `scripts/brew-update.sh`,
+  `scripts/mas-update.sh`, `scripts/npm-update.sh`, `utils/autogit.sh`) report
+  `SC1071` ("ShellCheck only supports sh/bash/dash/ksh") — this is expected, not a real
+  failure. There are also pre-existing style/info findings; do not treat them as new breakage.
+
+### Running the product
+- `scripts/bootstrap-mac.sh` is **macOS-only** (uses `xcode-select`, Homebrew, `chsh`,
+  `defaults`) and cannot run on the Linux cloud VM.
+- `deploy.sh` is the cross-platform core; it detects Ubuntu/Debian and takes a Linux path.
+  It uses `sudo apt-get install` and network (installs oh-my-zsh via curl, clones Vundle),
+  so it needs sudo + egress (both available on the cloud VM). It has no `set -e`, so
+  individual step failures are non-fatal and it still prints `setup complete!`.
+
+### Non-obvious gotchas when running `deploy.sh`
+- It runs against `$HOME` directly and would modify the VM's real home. To exercise it
+  safely/repeatably, run it under a throwaway `HOME` with a repo copy at `$HOME/dotfiles`,
+  e.g. `HOME=/tmp/demo sh /tmp/demo/dotfiles/deploy.sh`.
+- `update_repo()` does `cd ~/dotfiles && git pull` — it requires `~/dotfiles` to exist;
+  a missing upstream just prints a warning and is ignored.
+- It only creates `~/.config/nvim` if `~/.config` already exists; a bare sandbox HOME
+  triggers a harmless `ln: ... No such file or directory` for that one symlink.
+- `shells/zshrc`: for **non-root interactive Linux** shells it auto-attaches/creates tmux
+  and `exit 0`s. When scripting a demo, set `TMUX=<anything>` (or run inside tmux) to keep
+  the shell in the foreground so it does not get hijacked.
+
+### Verifying the deployed shell
+After `deploy.sh`, launching `zsh -i` from the deployed `$HOME` loads oh-my-zsh with the
+custom `digitalnomad` theme (two-line `╭…`/`╰±` prompt), the Linux plugin set
+`git tmux vi-mode`, and aliases from `shells/sh_aliases` (e.g. `ll`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for this **dotfiles** repo in Cursor Cloud and documents durable, non-obvious run/lint notes for future agents.

This repo has no server app, build, or test suite — the "product" is the bootstrap/deploy tooling plus editor/shell configs. Development activities here are **linting the shell scripts** and **running `deploy.sh`** (the cross-platform dotfiles deployer).

## Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section (lint command, macOS-only vs Linux scripts, and non-obvious `deploy.sh` gotchas). No existing code modified.

## Environment
- **Update script** (installs missing dev tools, idempotent): installs `shellcheck` (linter) and `zsh` (runtime for the shell configs) via `apt` only if absent.

## Verification performed
- **Lint:** `shellcheck` (0.9.0) run across all 11 `*.sh` files. Runs clean; only pre-existing style/info findings and expected `SC1071` on zsh-shebang scripts.
- **Run:** `deploy.sh` executed end-to-end under a sandbox `HOME` — apt-installed the Linux package set, installed oh-my-zsh, created all dotfile symlinks, and cloned Vundle (`setup complete!`).
- **Hello-world:** launched `zsh -i` with the deployed config — oh-my-zsh loads the custom `digitalnomad` theme, plugins `git tmux vi-mode`, and the `ll` alias / `update-dotfiles` function all work.

[Deployed zsh with digitalnomad theme](https://cursor.com/agents/bc-34122fbc-ef24-48fc-b49c-c7238b5e9fa5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeployed_zsh_themed_prompt.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34122fbc-ef24-48fc-b49c-c7238b5e9fa5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34122fbc-ef24-48fc-b49c-c7238b5e9fa5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

