### PR TITLE
Neovim Emacs feature parity (draft)

### DIFF
--- a/editors/nvim/EMACS-PARITY.md
+++ b/editors/nvim/EMACS-PARITY.md
@@ -52,7 +52,7 @@ This is intentionally **not** a full Emacs reimplementation. Org agenda depth, m
 | projectile + ivy/counsel | Telescope (+ git root) |
 | envrc | direnv.vim |
 | editorconfig | Neovim built-in (`vim.g.editorconfig`) |
-| yasnippet | LuaSnip + friendly-snippets (+ Emacs snipmate dirs if present) |
+| yasnippet | LuaSnip + friendly-snippets (+ optional `stdpath('config')/snippets`) |
 | solarized + auto-dark | solarized.nvim + auto-dark-mode.nvim |
 | org-mode | nvim-orgmode (basic) |
 | deft | Telescope notes dirs |

--- a/editors/nvim/EMACS-PARITY.md
+++ b/editors/nvim/EMACS-PARITY.md
@@ -77,6 +77,17 @@ This is intentionally **not** a full Emacs reimplementation. Org agenda depth, m
 - **CIDER** test runners / clj-refactor — Conjure covers eval/doc; jack-in UX differs
 - **lsp-java** project import polish — `jdtls` via Mason is the stand-in
 
+## Optional trims (if you want a thinner config)
+
+Everything below works and is tested; pull out only if you prefer less surface area:
+
+| Piece | Why you might drop it |
+| --- | --- |
+| `orgmode` | Emacs remains the better Org daily driver; nvim-orgmode is basic |
+| `kulala` | Only needed if you edit `.http` restclient files in nvim |
+| `jdtls` / `elixirls` Mason servers | Heavy first-time installs if you rarely touch Java/Elixir in nvim |
+| `text-case` (`,si*`) | Convenience; not needed for core edit/LSP/git flow |
+
 ## Quick verification
 
 ```sh

--- a/editors/nvim/EMACS-PARITY.md
+++ b/editors/nvim/EMACS-PARITY.md
@@ -1,0 +1,89 @@
+# Emacs → Neovim feature parity
+
+Goal: open Neovim and operate with the same muscle memory as `editors/emacs-config.org` (`,` leader, language tooling, git, navigation).
+
+This is intentionally **not** a full Emacs reimplementation. Org agenda depth, multi-term shell visor, and perspectives are thinner or deferred in favor of tmux + Neovim-native tools.
+
+## Shared muscle memory
+
+| Emacs (evil-leader `,`) | Neovim | Notes |
+| --- | --- | --- |
+| `,t` project file | `,t` Telescope git files | |
+| `,b` buffer switch | `,b` Telescope buffers | |
+| `,gf` project grep | `,gf` Telescope live_grep | |
+| `,Ff` find file | `,Ff` Telescope find_files | |
+| `,Fd` dired here | `,Fd` netrw (`:Ex`) | |
+| `,nt` neotree | `,nt` neo-tree | |
+| `,ww` / `,wq` / `,qq` | same | |
+| `,/` clear search hl | same | |
+| `,nn` toggle line numbers | same | |
+| `,wc` / `,wm` window close/main | same | |
+| `,jl` avy line | EasyMotion `,jl` | also `,jw` / `,jc` |
+| `,cl` comment lines | Comment.nvim | |
+| `,m` Marked preview | same (macOS) | |
+| `,ev` / `,sv` | edit / reload nvim options+keymaps | Emacs uses `,ee` / `,se` for emacs |
+| `,jd` lsp definition | same | also kickstart `grd` |
+| `,fu` lsp references | same | also kickstart `grr` |
+| `,gst` magit status | Neogit | |
+| `,gg` magit dispatch | Neogit floating | |
+| `,gca` / `,gaa` / `,gpu`… | Magit-shaped git maps | uses Neogit + Fugitive `:Git` |
+| `,fcn` / `,fcp` / `,fcl` / `,fcb` | diagnostic next/prev/list/refresh | |
+| `,dw` delete trailing ws | same | |
+| `,lt` truncate-lines toggle | `wrap!` | |
+| `,kb` kill buffer | `Bclose` | keeps split |
+| `,kr` kill-ring / yank history | Telescope `registers` | |
+| `,ml` / `,ms` / `,md` bookmarks | Telescope marks + `:mark` / `:delmarks` | |
+| `,Pl` package list | `:Lazy` | |
+| `,nc` / `,np` / `,nw` deft notes | Telescope in `~/notes/{common,personal,work}` | |
+| `,fb` format buffer | Conform | was bare `,f` in stock Kickstart |
+| `,sit` / `,sic` / `,sik` / `,sis` | text-case.nvim | |
+| `,dd` dash-at-point | Dash.app (macOS) | |
+| CIDER `,eb` / `,ef` / `,ri`… | Conjure (clojure ft) | |
+| restclient `,ef` | kulala on `.http` | |
+
+## Language / tooling map
+
+| Emacs | Neovim |
+| --- | --- |
+| lsp-mode + company | mason + lspconfig + blink.cmp |
+| flycheck | nvim-lint + vim.diagnostic |
+| prettier / eslint / black / rubocop / goimports | Conform + eslint LSP + mason tools |
+| CIDER | Conjure |
+| projectile + ivy/counsel | Telescope (+ git root) |
+| envrc | direnv.vim |
+| editorconfig | Neovim built-in (`vim.g.editorconfig`) |
+| yasnippet | LuaSnip + friendly-snippets (+ Emacs snipmate dirs if present) |
+| solarized + auto-dark | solarized.nvim + auto-dark-mode.nvim |
+| org-mode | nvim-orgmode (basic) |
+| deft | Telescope notes dirs |
+| magit + diff-hl | Neogit + gitsigns |
+| paredit / rainbow | nvim-paredit + rainbow-delimiters |
+
+### LSP servers enabled
+
+`clangd`, `gopls`, `pyright`, `rust_analyzer`, `ts_ls`, `bashls`, `html`, `cssls`, `jsonls`, `yamlls`, `dockerls`, `eslint`, `lua_ls`, `ruby_lsp`, `clojure_lsp`, `jdtls`, `elixirls`, `terraformls`, `graphql`
+
+### Linters (nvim-lint)
+
+`eslint_d` (js/ts), `clj-kondo`, `shellcheck`, `cfn_lint`, `rubocop` — tools installed via Mason where available; `cfn-lint` / `clj-kondo` also come from the Brewfile on macOS.
+
+## Known gaps (intentionally thinner)
+
+- **Perspectives** (`persp-*`): use tmux sessions/windows or Neovim tab pages for now
+- **multi-term shell visor** (`,sv` in Emacs): keep using tmux; Neovim `,sv` reloads config
+- **Full Org** agenda / pomodoro / Mac Mail links / HTML agenda export
+- **Atomic Chrome**, **Dash** depth beyond macOS URL handler
+- **aggressive-indent**, **column-enforce**, **typo-mode**
+- **CIDER** test runners / clj-refactor — Conjure covers eval/doc; jack-in UX differs
+- **lsp-java** project import polish — `jdtls` via Mason is the stand-in
+
+## Quick verification
+
+```sh
+export XDG_CONFIG_HOME=/path/to/dotfiles/editors
+export XDG_DATA_HOME=/tmp/nvim-test/share
+export XDG_STATE_HOME=/tmp/nvim-test/state
+export XDG_CACHE_HOME=/tmp/nvim-test/cache
+nvim --headless "+Lazy! sync" "+qa"
+nvim  # then try ,gst ,jd ,fu ,t ,gf ,nt
+```

--- a/editors/nvim/README.md
+++ b/editors/nvim/README.md
@@ -1,5 +1,9 @@
 # kickstart-modular.nvim
 
+This is intentionally **not** a full Emacs reimplementation. Org agenda depth, multi-term shell visor, and perspectives are thinner or deferred in favor of tmux + Neovim-native tools.
+
+See also: [EMACS-PARITY.md](./EMACS-PARITY.md) for the keybind and language tooling map.
+
 ## Introduction
 
 *This is a fork of [nvim-lua/kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim) that moves from a single file to a multi file configuration.*

--- a/editors/nvim/lua/custom/plugins/conjure.lua
+++ b/editors/nvim/lua/custom/plugins/conjure.lua
@@ -16,22 +16,27 @@ return {
     config = function()
       -- Emacs CIDER-shaped aliases (buffer-local when Conjure attaches)
       local group = vim.api.nvim_create_augroup('emacs-parity-conjure', { clear = true })
+      local function set_cider_maps(buf)
+        local opts = { buffer = buf, silent = true }
+        vim.keymap.set('n', '<leader>ri', '<cmd>ConjureLogVSplit<CR>', vim.tbl_extend('force', opts, { desc = 'REPL: open log' }))
+        vim.keymap.set('n', '<leader>rq', '<cmd>ConjureClientStateReset<CR>', vim.tbl_extend('force', opts, { desc = 'REPL: reset client' }))
+        vim.keymap.set('n', '<leader>eb', '<cmd>ConjureEvalBuf<CR>', vim.tbl_extend('force', opts, { desc = 'Eval buffer' }))
+        vim.keymap.set('n', '<leader>ef', '<cmd>ConjureEvalCurrentForm<CR>', vim.tbl_extend('force', opts, { desc = 'Eval form' }))
+        vim.keymap.set('n', '<leader>es', '<cmd>ConjureEvalCurrentForm<CR>', vim.tbl_extend('force', opts, { desc = 'Eval sexp' }))
+        vim.keymap.set('n', '<leader>rb', '<cmd>ConjureLogVSplit<CR>', vim.tbl_extend('force', opts, { desc = 'REPL buffer' }))
+        vim.keymap.set('n', '<leader>ds', '<cmd>ConjureDocWord<CR>', vim.tbl_extend('force', opts, { desc = 'Doc under cursor' }))
+      end
       vim.api.nvim_create_autocmd('FileType', {
         group = group,
         pattern = { 'clojure', 'fennel', 'janet', 'racket', 'scheme', 'lisp', 'hy' },
         callback = function(args)
-          local opts = { buffer = args.buf, silent = true }
-          -- (r)epl (i)nit / connect — Conjure auto-connects; this focuses log
-          vim.keymap.set('n', '<leader>ri', '<cmd>ConjureLogVSplit<CR>', vim.tbl_extend('force', opts, { desc = 'REPL: open log' }))
-          vim.keymap.set('n', '<leader>rq', '<cmd>ConjureClientStateReset<CR>', vim.tbl_extend('force', opts, { desc = 'REPL: reset client' }))
-          -- Eval aliases matching CIDER
-          vim.keymap.set('n', '<leader>eb', '<cmd>ConjureEvalBuf<CR>', vim.tbl_extend('force', opts, { desc = 'Eval buffer' }))
-          vim.keymap.set('n', '<leader>ef', '<cmd>ConjureEvalCurrentForm<CR>', vim.tbl_extend('force', opts, { desc = 'Eval form' }))
-          vim.keymap.set('n', '<leader>es', '<cmd>ConjureEvalCurrentForm<CR>', vim.tbl_extend('force', opts, { desc = 'Eval sexp' }))
-          vim.keymap.set('n', '<leader>rb', '<cmd>ConjureLogVSplit<CR>', vim.tbl_extend('force', opts, { desc = 'REPL buffer' }))
-          vim.keymap.set('n', '<leader>ds', '<cmd>ConjureDocWord<CR>', vim.tbl_extend('force', opts, { desc = 'Doc under cursor' }))
+          set_cider_maps(args.buf)
         end,
       })
+      -- If Conjure lazy-loaded after filetype was already set, attach to current buffer
+      if vim.tbl_contains({ 'clojure', 'fennel', 'janet', 'racket', 'scheme', 'lisp', 'hy' }, vim.bo.filetype) then
+        set_cider_maps(vim.api.nvim_get_current_buf())
+      end
     end,
   },
 }

--- a/editors/nvim/lua/custom/plugins/conjure.lua
+++ b/editors/nvim/lua/custom/plugins/conjure.lua
@@ -1,0 +1,37 @@
+-- Clojure/Lisp REPL — Conjure as CIDER stand-in
+-- Localleader is `,` (same as Emacs evil-leader), so Conjure maps stay familiar.
+return {
+  {
+    'Olical/conjure',
+    ft = { 'clojure', 'fennel', 'janet', 'racket', 'scheme', 'lisp', 'hy' },
+    init = function()
+      -- Keep Conjure on localleader (`,`) like Emacs CIDER leader maps
+      vim.g['conjure#mapping#prefix'] = ','
+      -- Prefer HUD + log without stealing focus on connect
+      vim.g['conjure#log#hud#enabled'] = true
+      vim.g['conjure#log#wrap'] = true
+      -- Clojure: jack-in helpers via vim-jack-in / fireplace are optional;
+      -- document `,ri` style binds via which-key aliases below.
+    end,
+    config = function()
+      -- Emacs CIDER-shaped aliases (buffer-local when Conjure attaches)
+      local group = vim.api.nvim_create_augroup('emacs-parity-conjure', { clear = true })
+      vim.api.nvim_create_autocmd('FileType', {
+        group = group,
+        pattern = { 'clojure', 'fennel', 'janet', 'racket', 'scheme', 'lisp', 'hy' },
+        callback = function(args)
+          local opts = { buffer = args.buf, silent = true }
+          -- (r)epl (i)nit / connect — Conjure auto-connects; this focuses log
+          vim.keymap.set('n', '<leader>ri', '<cmd>ConjureLogVSplit<CR>', vim.tbl_extend('force', opts, { desc = 'REPL: open log' }))
+          vim.keymap.set('n', '<leader>rq', '<cmd>ConjureClientStateReset<CR>', vim.tbl_extend('force', opts, { desc = 'REPL: reset client' }))
+          -- Eval aliases matching CIDER
+          vim.keymap.set('n', '<leader>eb', '<cmd>ConjureEvalBuf<CR>', vim.tbl_extend('force', opts, { desc = 'Eval buffer' }))
+          vim.keymap.set('n', '<leader>ef', '<cmd>ConjureEvalCurrentForm<CR>', vim.tbl_extend('force', opts, { desc = 'Eval form' }))
+          vim.keymap.set('n', '<leader>es', '<cmd>ConjureEvalCurrentForm<CR>', vim.tbl_extend('force', opts, { desc = 'Eval sexp' }))
+          vim.keymap.set('n', '<leader>rb', '<cmd>ConjureLogVSplit<CR>', vim.tbl_extend('force', opts, { desc = 'REPL buffer' }))
+          vim.keymap.set('n', '<leader>ds', '<cmd>ConjureDocWord<CR>', vim.tbl_extend('force', opts, { desc = 'Doc under cursor' }))
+        end,
+      })
+    end,
+  },
+}

--- a/editors/nvim/lua/custom/plugins/direnv.lua
+++ b/editors/nvim/lua/custom/plugins/direnv.lua
@@ -1,7 +1,11 @@
 -- Load project .envrc (Emacs envrc-mode parity)
+-- Only enable when direnv is on PATH (Brewfile installs it on Mac).
 return {
   {
     'direnv/direnv.vim',
     lazy = false,
+    cond = function()
+      return vim.fn.executable 'direnv' == 1
+    end,
   },
 }

--- a/editors/nvim/lua/custom/plugins/direnv.lua
+++ b/editors/nvim/lua/custom/plugins/direnv.lua
@@ -1,0 +1,7 @@
+-- Load project .envrc (Emacs envrc-mode parity)
+return {
+  {
+    'direnv/direnv.vim',
+    lazy = false,
+  },
+}

--- a/editors/nvim/lua/custom/plugins/easymotion.lua
+++ b/editors/nvim/lua/custom/plugins/easymotion.lua
@@ -1,13 +1,15 @@
--- EasyMotion-style line jump (matches IdeaVim `,jl` and old vimrc)
+-- EasyMotion jumps matching Emacs avy maps (,jl / ,jw / ,jc)
 return {
   {
     'easymotion/vim-easymotion',
     keys = {
       -- remap=true required so <Plug> maps resolve
       { '<leader>jl', '<Plug>(easymotion-bd-jk)', desc = 'EasyMotion jump to line', mode = { 'n', 'x', 'o' }, remap = true },
+      { '<leader>jw', '<Plug>(easymotion-bd-w)', desc = 'EasyMotion jump to word', mode = { 'n', 'x', 'o' }, remap = true },
+      { '<leader>jc', '<Plug>(easymotion-bd-f)', desc = 'EasyMotion jump to char', mode = { 'n', 'x', 'o' }, remap = true },
     },
     init = function()
-      -- Disable default EasyMotion mappings; we only want `,jl`
+      -- Disable default EasyMotion mappings; we only want explicit leader maps
       vim.g.EasyMotion_do_mapping = 0
     end,
   },

--- a/editors/nvim/lua/custom/plugins/neogit.lua
+++ b/editors/nvim/lua/custom/plugins/neogit.lua
@@ -1,0 +1,134 @@
+-- Magit-style Git UI (Neogit) with Emacs evil-leader keybinds
+return {
+  {
+    'NeogitOrg/neogit',
+    dependencies = {
+      'nvim-lua/plenary.nvim',
+      'sindrets/diffview.nvim',
+      'nvim-telescope/telescope.nvim',
+    },
+    cmd = 'Neogit',
+    keys = {
+      {
+        '<leader>gst',
+        function()
+          require('neogit').open()
+        end,
+        desc = 'Git status (Magit)',
+      },
+      {
+        '<leader>gg',
+        function()
+          require('neogit').open { kind = 'floating' }
+        end,
+        desc = 'Git dispatch (Neogit)',
+      },
+      {
+        '<leader>gd',
+        function()
+          vim.cmd 'DiffviewOpen'
+        end,
+        desc = 'Git diff working tree',
+      },
+      {
+        '<leader>gco',
+        function()
+          require('telescope.builtin').git_branches()
+        end,
+        desc = 'Git checkout branch',
+      },
+      {
+        '<leader>gcm',
+        function()
+          require('telescope.builtin').git_branches()
+        end,
+        desc = 'Git checkout branch',
+      },
+      {
+        '<leader>gcb',
+        function()
+          vim.ui.input({ prompt = 'New branch: ' }, function(name)
+            if name and name ~= '' then
+              vim.fn.system { 'git', 'checkout', '-b', name }
+              require('neogit').open()
+            end
+          end)
+        end,
+        desc = 'Git create and checkout branch',
+      },
+      {
+        '<leader>gl',
+        function()
+          vim.cmd 'Git pull'
+        end,
+        desc = 'Git pull upstream',
+      },
+      {
+        '<leader>gaa',
+        function()
+          vim.cmd 'Git add -u'
+          vim.notify('Staged modified files', vim.log.levels.INFO)
+        end,
+        desc = 'Git stage modified',
+      },
+      {
+        '<leader>grh',
+        function()
+          vim.cmd 'Git reset HEAD'
+        end,
+        desc = 'Git reset HEAD',
+      },
+      {
+        '<leader>gca',
+        function()
+          require('neogit').open { 'commit' }
+        end,
+        desc = 'Git commit',
+      },
+      {
+        '<leader>gpu',
+        function()
+          vim.cmd 'Git push -u'
+        end,
+        desc = 'Git push upstream',
+      },
+      {
+        '<leader>gpp',
+        function()
+          vim.cmd 'Git push'
+        end,
+        desc = 'Git push remote',
+      },
+      {
+        '<leader>gt',
+        function()
+          vim.ui.input({ prompt = 'Tag name: ' }, function(name)
+            if name and name ~= '' then
+              vim.fn.system { 'git', 'tag', name }
+              vim.notify('Created tag ' .. name, vim.log.levels.INFO)
+            end
+          end)
+        end,
+        desc = 'Git tag',
+      },
+      {
+        '<leader>gpt',
+        function()
+          vim.cmd 'Git push --tags'
+        end,
+        desc = 'Git push tags',
+      },
+    },
+    opts = {
+      integrations = {
+        telescope = true,
+        diffview = true,
+      },
+    },
+  },
+  {
+    -- Fugitive provides :Git used by Magit-parity keybinds above
+    'tpope/vim-fugitive',
+    cmd = { 'Git', 'G', 'Gdiffsplit', 'Gread', 'Gwrite', 'Ggrep', 'GMove', 'GDelete' },
+  },
+}

--- a/editors/nvim/lua/custom/plugins/orgmode.lua
+++ b/editors/nvim/lua/custom/plugins/orgmode.lua
@@ -1,0 +1,18 @@
+-- Basic Org-mode support (agenda/capture are thinner than Emacs; see EMACS-PARITY.md)
+return {
+  {
+    'nvim-orgmode/orgmode',
+    ft = { 'org' },
+    event = 'VeryLazy',
+    config = function()
+      require('orgmode').setup {
+        org_agenda_files = { '~/org/**/*', '~/notes/**/*.org' },
+        org_default_notes_file = '~/org/refile.org',
+        org_startup_indented = true,
+        mappings = {
+          prefix = '<Leader>o',
+        },
+      }
+    end,
+  },
+}

--- a/editors/nvim/lua/custom/plugins/rest.lua
+++ b/editors/nvim/lua/custom/plugins/rest.lua
@@ -1,0 +1,22 @@
+-- REST client for .http files (Emacs restclient-mode parity)
+return {
+  {
+    'mistweaverco/kulala.nvim',
+    ft = { 'http', 'rest' },
+    keys = {
+      { '<leader>ef', function() require('kulala').run() end, desc = 'REST: send request', ft = { 'http', 'rest' } },
+    },
+    opts = {
+      global_keymaps = false,
+      kulala_keymaps = true,
+    },
+    config = function(_, opts)
+      require('kulala').setup(opts)
+      vim.filetype.add {
+        extension = {
+          http = 'http',
+        },
+      }
+    end,
+  },
+}

--- a/editors/nvim/lua/custom/plugins/snippets.lua
+++ b/editors/nvim/lua/custom/plugins/snippets.lua
@@ -1,5 +1,5 @@
--- Load personal + friendly snippets (Emacs yasnippet parity)
--- LuaSnip itself is owned by blink.cmp in auto-complete.lua; this only adds snippet sources.
+-- Load personal + friendly snippets (yasnippet-style parity without sharing Emacs dirs)
+-- LuaSnip itself is also pulled in by blink.cmp in auto-complete.lua; this adds snippet sources.
 return {
   {
     'rafamadriz/friendly-snippets',
@@ -14,13 +14,10 @@ return {
       if not snipmate_ok then
         return
       end
+      -- Optional Neovim-local snippets only (not ~/.emacs.d/snippets)
       local personal = vim.fn.stdpath 'config' .. '/snippets'
       if vim.fn.isdirectory(personal) == 1 then
         snipmate.lazy_load { paths = { personal } }
-      end
-      local emacs_snip = vim.fn.expand '~/.emacs.d/snippets'
-      if vim.fn.isdirectory(emacs_snip) == 1 then
-        snipmate.lazy_load { paths = { emacs_snip } }
       end
     end,
   },
@@ -35,10 +32,6 @@ return {
       local personal = vim.fn.stdpath 'config' .. '/snippets'
       if vim.fn.isdirectory(personal) == 1 then
         snipmate.lazy_load { paths = { personal } }
-      end
-      local emacs_snip = vim.fn.expand '~/.emacs.d/snippets'
-      if vim.fn.isdirectory(emacs_snip) == 1 then
-        snipmate.lazy_load { paths = { emacs_snip } }
       end
     end,
   },

--- a/editors/nvim/lua/custom/plugins/snippets.lua
+++ b/editors/nvim/lua/custom/plugins/snippets.lua
@@ -1,0 +1,45 @@
+-- Load personal + friendly snippets (Emacs yasnippet parity)
+-- LuaSnip itself is owned by blink.cmp in auto-complete.lua; this only adds snippet sources.
+return {
+  {
+    'rafamadriz/friendly-snippets',
+    lazy = true,
+    config = function()
+      -- Loaded once LuaSnip is available (blink pulls it in on InsertEnter)
+      local ok, loader = pcall(require, 'luasnip.loaders.from_vscode')
+      if ok then
+        loader.lazy_load()
+      end
+      local snipmate_ok, snipmate = pcall(require, 'luasnip.loaders.from_snipmate')
+      if not snipmate_ok then
+        return
+      end
+      local personal = vim.fn.stdpath 'config' .. '/snippets'
+      if vim.fn.isdirectory(personal) == 1 then
+        snipmate.lazy_load { paths = { personal } }
+      end
+      local emacs_snip = vim.fn.expand '~/.emacs.d/snippets'
+      if vim.fn.isdirectory(emacs_snip) == 1 then
+        snipmate.lazy_load { paths = { emacs_snip } }
+      end
+    end,
+  },
+  {
+    -- Ensure LuaSnip loads friendly-snippets when completion starts
+    'L3MON4D3/LuaSnip',
+    dependencies = { 'rafamadriz/friendly-snippets' },
+    event = 'InsertEnter',
+    config = function()
+      require('luasnip.loaders.from_vscode').lazy_load()
+      local snipmate = require 'luasnip.loaders.from_snipmate'
+      local personal = vim.fn.stdpath 'config' .. '/snippets'
+      if vim.fn.isdirectory(personal) == 1 then
+        snipmate.lazy_load { paths = { personal } }
+      end
+      local emacs_snip = vim.fn.expand '~/.emacs.d/snippets'
+      if vim.fn.isdirectory(emacs_snip) == 1 then
+        snipmate.lazy_load { paths = { emacs_snip } }
+      end
+    end,
+  },
+}

--- a/editors/nvim/lua/custom/plugins/string-case.lua
+++ b/editors/nvim/lua/custom/plugins/string-case.lua
@@ -1,0 +1,51 @@
+-- string-inflection parity (camelCase / kebab / snake cycling)
+return {
+  {
+    'johmsalas/text-case.nvim',
+    keys = {
+      {
+        '<leader>sit',
+        function()
+          -- Cycle snake → kebab → camel → snake (closest to string-inflection-all-cycle)
+          local word = vim.fn.expand '<cword>'
+          if word == '' then
+            return
+          end
+          local textcase = require 'textcase'
+          if word:find '_' then
+            textcase.current_word 'to_dash_case'
+          elseif word:find '-' then
+            textcase.current_word 'to_camel_case'
+          else
+            textcase.current_word 'to_snake_case'
+          end
+        end,
+        desc = 'Case: cycle snake/kebab/camel',
+      },
+      {
+        '<leader>sic',
+        function()
+          require('textcase').current_word 'to_camel_case'
+        end,
+        desc = 'Case: lowerCamel',
+      },
+      {
+        '<leader>sik',
+        function()
+          require('textcase').current_word 'to_dash_case'
+        end,
+        desc = 'Case: kebab',
+      },
+      {
+        '<leader>sis',
+        function()
+          require('textcase').current_word 'to_snake_case'
+        end,
+        desc = 'Case: snake',
+      },
+    },
+    config = function()
+      require('textcase').setup {}
+    end,
+  },
+}

--- a/editors/nvim/lua/custom/plugins/string-case.lua
+++ b/editors/nvim/lua/custom/plugins/string-case.lua
@@ -1,4 +1,56 @@
 -- string-inflection parity (camelCase / kebab / snake cycling)
+-- Uses text-case.nvim's conversion library with an in-buffer replace that works
+-- from Lua keymaps (plugin's current_word() relies on feedkeys/operatorfunc).
+local function cword_bounds()
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  local line = vim.api.nvim_get_current_line()
+  if line == '' then
+    return nil
+  end
+  local c = col + 1 -- 1-based
+  if c > #line then
+    c = #line
+  end
+  -- Treat snake / kebab / alnum as one identifier (Emacs string-inflection style)
+  local function is_ident(ch)
+    return ch and ch:match '[%w_%-]' ~= nil
+  end
+  if not is_ident(line:sub(c, c)) then
+    -- If cursor is on a boundary, prefer the identifier to the right, else left
+    if is_ident(line:sub(c + 1, c + 1)) then
+      c = c + 1
+    elseif c > 1 and is_ident(line:sub(c - 1, c - 1)) then
+      c = c - 1
+    else
+      return nil
+    end
+  end
+  while c > 1 and is_ident(line:sub(c - 1, c - 1)) do
+    c = c - 1
+  end
+  local s = c
+  while c <= #line and is_ident(line:sub(c, c)) do
+    c = c + 1
+  end
+  local word = line:sub(s, c - 1)
+  if word == '' then
+    return nil
+  end
+  return row - 1, s - 1, c - 1, word
+end
+
+local function apply_case(converter)
+  local row, start_col, end_col, word = cword_bounds()
+  if not word then
+    return
+  end
+  local new_word = converter(word)
+  if not new_word or new_word == word then
+    return
+  end
+  vim.api.nvim_buf_set_text(0, row, start_col, row, end_col, { new_word })
+end
+
 return {
   {
     'johmsalas/text-case.nvim',
@@ -6,40 +58,41 @@ return {
       {
         '<leader>sit',
         function()
-          -- Cycle snake → kebab → camel → snake (closest to string-inflection-all-cycle)
-          local word = vim.fn.expand '<cword>'
-          if word == '' then
+          local row, start_col, end_col, word = cword_bounds()
+          if not word then
             return
           end
-          local textcase = require 'textcase'
+          local api = require('textcase').api
+          local next_word
           if word:find '_' then
-            textcase.current_word 'to_dash_case'
+            next_word = api.to_dash_case(word)
           elseif word:find '-' then
-            textcase.current_word 'to_camel_case'
+            next_word = api.to_camel_case(word)
           else
-            textcase.current_word 'to_snake_case'
+            next_word = api.to_snake_case(word)
           end
+          vim.api.nvim_buf_set_text(0, row, start_col, row, end_col, { next_word })
         end,
         desc = 'Case: cycle snake/kebab/camel',
       },
       {
         '<leader>sic',
         function()
-          require('textcase').current_word 'to_camel_case'
+          apply_case(require('textcase').api.to_camel_case)
         end,
         desc = 'Case: lowerCamel',
       },
       {
         '<leader>sik',
         function()
-          require('textcase').current_word 'to_dash_case'
+          apply_case(require('textcase').api.to_dash_case)
         end,
         desc = 'Case: kebab',
       },
       {
         '<leader>sis',
         function()
-          require('textcase').current_word 'to_snake_case'
+          apply_case(require('textcase').api.to_snake_case)
         end,
         desc = 'Case: snake',
       },

--- a/editors/nvim/lua/keymaps.lua
+++ b/editors/nvim/lua/keymaps.lua
@@ -136,8 +136,8 @@ vim.keymap.set('n', '<leader><Right>', '<cmd>vertical resize -5<CR>', { desc = '
 vim.keymap.set('n', '<leader>cd', '<cmd>cd %:p:h<CR><cmd>pwd<CR>', { desc = "cd to current file's directory" })
 vim.keymap.set('n', '<leader>cds', '<cmd>cd ~/src<CR><cmd>pwd<CR>', { desc = 'cd to ~/src' })
 
--- Preview current file in Marked 2 (macOS only)
-vim.keymap.set('n', '<leader>m', function()
+-- Preview current file in Marked 2 (macOS only) — Emacs markdown ,Mp
+vim.keymap.set('n', '<leader>Mp', function()
   if vim.fn.has 'mac' == 0 and vim.fn.has 'macunix' == 0 then
     vim.notify('Marked 2 preview is only available on macOS', vim.log.levels.WARN)
     return
@@ -145,6 +145,15 @@ vim.keymap.set('n', '<leader>m', function()
   local path = vim.fn.expand '%:p'
   vim.fn.jobstart({ 'open', '-a', 'Marked 2.app', path }, { detach = true })
 end, { desc = 'Preview in Marked 2' })
+-- Keep old ,m alias for vimrc muscle memory
+vim.keymap.set('n', '<leader>m', function()
+  if vim.fn.has 'mac' == 0 and vim.fn.has 'macunix' == 0 then
+    vim.notify('Marked 2 preview is only available on macOS', vim.log.levels.WARN)
+    return
+  end
+  local path = vim.fn.expand '%:p'
+  vim.fn.jobstart({ 'open', '-a', 'Marked 2.app', path }, { detach = true })
+end, { desc = 'Preview in Marked 2 (alias)' })
 
 -- Wrap-aware motion
 vim.keymap.set({ 'n', 'x' }, 'j', 'gj', { desc = 'Down (display line)' })
@@ -222,6 +231,133 @@ end, { desc = 'Close buffer without closing split' })
 
 -- Make :bd use Bclose (keeps the split layout)
 vim.cmd [[cnoreabbrev <expr> bd (getcmdtype() ==# ':' && getcmdline() ==# 'bd') ? 'Bclose' : 'bd']]
+
+------------
+-- EMACS PARITY KEYBINDS
+-- Matching evil-leader maps from editors/emacs-config.org
+------------
+
+-- (k)ill (b)uffer without destroying the split
+vim.keymap.set('n', '<leader>kb', '<cmd>Bclose<CR>', { desc = 'Kill buffer (keep split)' })
+
+-- (d)elete trailing (w)hitespace
+vim.keymap.set('n', '<leader>dw', function()
+  local view = vim.fn.winsaveview()
+  vim.cmd [[keeppatterns %s/\s\+$//e]]
+  vim.fn.winrestview(view)
+end, { desc = 'Delete trailing whitespace' })
+
+-- (l)ine (t)runcate toggle (Emacs truncate-lines ↔ wrap)
+vim.keymap.set('n', '<leader>lt', '<cmd>setlocal wrap!<CR>', { desc = 'Toggle line wrap/truncate' })
+
+-- (k)ill-(r)ing / yank history
+vim.keymap.set('n', '<leader>kr', function()
+  require('telescope.builtin').registers()
+end, { desc = 'Yank / register history' })
+
+-- Bookmarks (Emacs bookmark-* )
+vim.keymap.set('n', '<leader>ml', function()
+  require('telescope.builtin').marks()
+end, { desc = 'Bookmark jump (list)' })
+vim.keymap.set('n', '<leader>mj', function()
+  require('telescope.builtin').marks()
+end, { desc = 'Bookmark jump' })
+vim.keymap.set('n', '<leader>ms', function()
+  vim.ui.input({ prompt = 'Mark name: ' }, function(name)
+    if name and name ~= '' then
+      vim.cmd('mark ' .. name)
+    end
+  end)
+end, { desc = 'Bookmark set' })
+vim.keymap.set('n', '<leader>md', function()
+  vim.ui.input({ prompt = 'Delete mark: ' }, function(name)
+    if name and name ~= '' then
+      vim.cmd('delmarks ' .. name)
+    end
+  end)
+end, { desc = 'Bookmark delete' })
+
+-- (P)ackage (l)ist → Lazy
+vim.keymap.set('n', '<leader>Pl', '<cmd>Lazy<CR>', { desc = 'Package list (Lazy)' })
+vim.keymap.set('n', '<leader>Pu', '<cmd>Lazy sync<CR>', { desc = 'Package update (Lazy sync)' })
+vim.keymap.set('n', '<leader>Pi', '<cmd>Lazy install<CR>', { desc = 'Package install' })
+
+-- Flycheck-shaped diagnostic maps
+vim.keymap.set('n', '<leader>fcn', function()
+  vim.diagnostic.jump { count = 1, float = true }
+end, { desc = 'Diagnostic next' })
+vim.keymap.set('n', '<leader>fcp', function()
+  vim.diagnostic.jump { count = -1, float = true }
+end, { desc = 'Diagnostic previous' })
+vim.keymap.set('n', '<leader>fcl', vim.diagnostic.setloclist, { desc = 'Diagnostic list' })
+vim.keymap.set('n', '<leader>fcb', function()
+  vim.diagnostic.reset()
+  if package.loaded['lint'] then
+    require('lint').try_lint()
+  end
+  vim.cmd 'edit' -- nudge LSP refresh
+  vim.notify('Diagnostics refreshed', vim.log.levels.INFO)
+end, { desc = 'Diagnostic refresh buffer' })
+
+-- Deft-shaped notes roots
+local function notes_telescope(subdir)
+  local root = vim.fn.expand('~/notes/' .. subdir)
+  if vim.fn.isdirectory(root) == 0 then
+    vim.notify('Notes dir missing: ' .. root, vim.log.levels.WARN)
+    return
+  end
+  require('telescope.builtin').find_files { cwd = root, prompt_title = 'Notes: ' .. subdir }
+end
+vim.keymap.set('n', '<leader>nc', function()
+  notes_telescope 'common'
+end, { desc = 'Notes: common' })
+vim.keymap.set('n', '<leader>np', function()
+  notes_telescope 'personal'
+end, { desc = 'Notes: personal' })
+vim.keymap.set('n', '<leader>nw', function()
+  notes_telescope 'work'
+end, { desc = 'Notes: work' })
+vim.keymap.set('n', '<leader>nf', function()
+  local roots = {
+    vim.fn.expand '~/notes/common',
+    vim.fn.expand '~/notes/personal',
+    vim.fn.expand '~/notes/work',
+  }
+  require('telescope.builtin').find_files {
+    search_dirs = roots,
+    prompt_title = 'Notes: all',
+  }
+end, { desc = 'Notes: find file' })
+
+-- (d)ash (d)oc — macOS Dash.app
+vim.keymap.set('n', '<leader>dd', function()
+  if vim.fn.has 'mac' == 0 and vim.fn.has 'macunix' == 0 then
+    vim.notify('Dash is only available on macOS', vim.log.levels.WARN)
+    return
+  end
+  local word = vim.fn.expand '<cword>'
+  if word == '' then
+    return
+  end
+  vim.fn.jobstart({ 'open', 'dash://' .. word }, { detach = true })
+end, { desc = 'Dash documentation' })
+
+-- (d)escribe (v)ariable — Lua/help stand-in for Emacs describe-variable
+vim.keymap.set('n', '<leader>dv', function()
+  require('telescope.builtin').help_tags()
+end, { desc = 'Describe / help tags' })
+
+-- Comment paragraph (evil-nerd-commenter ,cp)
+vim.keymap.set('n', '<leader>cp', function()
+  vim.cmd 'normal! vip'
+  require('Comment.api').toggle.linewise(vim.fn.visualmode())
+end, { desc = 'Comment paragraph' })
+
+-- Clear / recenter screen (Emacs ,cs)
+vim.keymap.set('n', '<leader>cs', 'zz', { desc = 'Clear / recenter screen' })
+
+-- EditorConfig is built into Neovim 0.9+; ensure enabled
+vim.g.editorconfig = true
 
 -- Netrw: make ^ behave like 'u' (parent directory)
 -- Some setups see netrw re-apply its own mappings after FileType runs.

--- a/editors/nvim/lua/keymaps.lua
+++ b/editors/nvim/lua/keymaps.lua
@@ -348,10 +348,12 @@ vim.keymap.set('n', '<leader>dv', function()
 end, { desc = 'Describe / help tags' })
 
 -- Comment paragraph (evil-nerd-commenter ,cp)
-vim.keymap.set('n', '<leader>cp', function()
-  vim.cmd 'normal! vip'
-  require('Comment.api').toggle.linewise(vim.fn.visualmode())
-end, { desc = 'Comment paragraph' })
+-- Use Comment.nvim's visual plug: enters visual on ip, then toggles the selection.
+vim.keymap.set('n', '<leader>cp', 'vip<Plug>(comment_toggle_linewise_visual)', {
+  remap = true,
+  silent = true,
+  desc = 'Comment paragraph',
+})
 
 -- Clear / recenter screen (Emacs ,cs)
 vim.keymap.set('n', '<leader>cs', 'zz', { desc = 'Clear / recenter screen' })

--- a/editors/nvim/lua/kickstart/plugins/conform.lua
+++ b/editors/nvim/lua/kickstart/plugins/conform.lua
@@ -1,16 +1,17 @@
 return {
-  { -- Autoformat
+  { -- Autoformat (Emacs prettier / goimports / rubocop / black parity)
     'stevearc/conform.nvim',
     event = { 'BufWritePre' },
     cmd = { 'ConformInfo' },
     keys = {
       {
-        '<leader>f',
+        -- Use ,fb so ,f* stays free for flycheck/find/format submaps (Emacs style)
+        '<leader>fb',
         function()
           require('conform').format { async = true, lsp_format = 'fallback' }
         end,
         mode = '',
-        desc = '[F]ormat buffer',
+        desc = '[F]ormat [B]uffer',
       },
     },
     opts = {
@@ -24,18 +25,27 @@ return {
           return nil
         else
           return {
-            timeout_ms = 500,
+            timeout_ms = 1000,
             lsp_format = 'fallback',
           }
         end
       end,
       formatters_by_ft = {
         lua = { 'stylua' },
-        -- Conform can also run multiple formatters sequentially
-        -- python = { "isort", "black" },
-        --
-        -- You can use 'stop_after_first' to run the first available formatter from the list
-        -- javascript = { "prettierd", "prettier", stop_after_first = true },
+        python = { 'isort', 'black' },
+        javascript = { 'prettierd', 'prettier', stop_after_first = true },
+        javascriptreact = { 'prettierd', 'prettier', stop_after_first = true },
+        typescript = { 'prettierd', 'prettier', stop_after_first = true },
+        typescriptreact = { 'prettierd', 'prettier', stop_after_first = true },
+        json = { 'prettierd', 'prettier', stop_after_first = true },
+        html = { 'prettierd', 'prettier', stop_after_first = true },
+        css = { 'prettierd', 'prettier', stop_after_first = true },
+        scss = { 'prettierd', 'prettier', stop_after_first = true },
+        markdown = { 'prettierd', 'prettier', stop_after_first = true },
+        yaml = { 'prettierd', 'prettier', stop_after_first = true },
+        go = { 'goimports', 'gofmt' },
+        ruby = { 'rubocop' },
+        terraform = { 'terraform_fmt' },
       },
     },
   },

--- a/editors/nvim/lua/kickstart/plugins/lint.lua
+++ b/editors/nvim/lua/kickstart/plugins/lint.lua
@@ -1,55 +1,50 @@
 return {
 
-  { -- Linting
+  { -- Linting (Emacs flycheck parity — only enable tools we actually use)
     'mfussenegger/nvim-lint',
     event = { 'BufReadPre', 'BufNewFile' },
     config = function()
       local lint = require 'lint'
+
+      -- Clear noisy defaults; opt into Emacs-parity linters explicitly
       lint.linters_by_ft = {
-        markdown = { 'markdownlint' },
+        clojure = { 'clj-kondo' },
+        clojurescript = { 'clj-kondo' },
+        javascript = { 'eslint_d' },
+        javascriptreact = { 'eslint_d' },
+        typescript = { 'eslint_d' },
+        typescriptreact = { 'eslint_d' },
+        sh = { 'shellcheck' },
+        bash = { 'shellcheck' },
+        zsh = { 'shellcheck' },
+        ruby = { 'rubocop' },
+        -- CloudFormation (cfn-lint from Brewfile); filetype set via autocmd below
+        cfn = { 'cfn_lint' },
       }
 
-      -- To allow other plugins to add linters to require('lint').linters_by_ft,
-      -- instead set linters_by_ft like this:
-      -- lint.linters_by_ft = lint.linters_by_ft or {}
-      -- lint.linters_by_ft['markdown'] = { 'markdownlint' }
-      --
-      -- However, note that this will enable a set of default linters,
-      -- which will cause errors unless these tools are available:
-      -- {
-      --   clojure = { "clj-kondo" },
-      --   dockerfile = { "hadolint" },
-      --   inko = { "inko" },
-      --   janet = { "janet" },
-      --   json = { "jsonlint" },
-      --   markdown = { "vale" },
-      --   rst = { "vale" },
-      --   ruby = { "ruby" },
-      --   terraform = { "tflint" },
-      --   text = { "vale" }
-      -- }
-      --
-      -- You can disable the default linters by setting their filetypes to nil:
-      -- lint.linters_by_ft['clojure'] = nil
-      -- lint.linters_by_ft['dockerfile'] = nil
-      -- lint.linters_by_ft['inko'] = nil
-      -- lint.linters_by_ft['janet'] = nil
-      -- lint.linters_by_ft['json'] = nil
-      -- lint.linters_by_ft['markdown'] = nil
-      -- lint.linters_by_ft['rst'] = nil
-      -- lint.linters_by_ft['ruby'] = nil
-      -- lint.linters_by_ft['terraform'] = nil
-      -- lint.linters_by_ft['text'] = nil
+      -- Detect CloudFormation templates (Emacs cfn-yaml-mode / cfn-json-mode)
+      vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
+        pattern = { '*.yaml', '*.yml', '*.json' },
+        callback = function(args)
+          local path = args.file
+          if path == '' then
+            return
+          end
+          local ok, lines = pcall(vim.fn.readfile, path, '', 20)
+          if not ok then
+            return
+          end
+          local head = table.concat(lines, '\n')
+          if head:find 'AWSTemplateFormatVersion' then
+            vim.bo[args.buf].filetype = 'cfn'
+          end
+        end,
+      })
 
-      -- Create autocommand which carries out the actual linting
-      -- on the specified events.
       local lint_augroup = vim.api.nvim_create_augroup('lint', { clear = true })
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
         callback = function()
-          -- Only run the linter in buffers that you can modify in order to
-          -- avoid superfluous noise, notably within the handy LSP pop-ups that
-          -- describe the hovered symbol using Markdown.
           if vim.bo.modifiable then
             lint.try_lint()
           end

--- a/editors/nvim/lua/kickstart/plugins/lint.lua
+++ b/editors/nvim/lua/kickstart/plugins/lint.lua
@@ -6,21 +6,43 @@ return {
     config = function()
       local lint = require 'lint'
 
-      -- Clear noisy defaults; opt into Emacs-parity linters explicitly
-      lint.linters_by_ft = {
-        clojure = { 'clj-kondo' },
-        clojurescript = { 'clj-kondo' },
-        javascript = { 'eslint_d' },
-        javascriptreact = { 'eslint_d' },
-        typescript = { 'eslint_d' },
-        typescriptreact = { 'eslint_d' },
-        sh = { 'shellcheck' },
-        bash = { 'shellcheck' },
-        zsh = { 'shellcheck' },
-        ruby = { 'rubocop' },
-        -- CloudFormation (cfn-lint from Brewfile); filetype set via autocmd below
-        cfn = { 'cfn_lint' },
-      }
+      local function exe(name)
+        return vim.fn.executable(name) == 1
+      end
+
+      -- Clear noisy defaults; opt into Emacs-parity linters when present on PATH
+      -- (Mason may install eslint_d/shellcheck/etc. later under stdpath data).
+      local function mason_bin(name)
+        return vim.fn.stdpath 'data' .. '/mason/bin/' .. name
+      end
+      local function available(name)
+        return exe(name) or exe(mason_bin(name))
+      end
+
+      lint.linters_by_ft = {}
+
+      if available 'clj-kondo' then
+        lint.linters_by_ft.clojure = { 'clj-kondo' }
+        lint.linters_by_ft.clojurescript = { 'clj-kondo' }
+      end
+      if available 'eslint_d' or available 'eslint' then
+        local eslint = available 'eslint_d' and 'eslint_d' or 'eslint'
+        lint.linters_by_ft.javascript = { eslint }
+        lint.linters_by_ft.javascriptreact = { eslint }
+        lint.linters_by_ft.typescript = { eslint }
+        lint.linters_by_ft.typescriptreact = { eslint }
+      end
+      if available 'shellcheck' then
+        lint.linters_by_ft.sh = { 'shellcheck' }
+        lint.linters_by_ft.bash = { 'shellcheck' }
+        lint.linters_by_ft.zsh = { 'shellcheck' }
+      end
+      if available 'rubocop' then
+        lint.linters_by_ft.ruby = { 'rubocop' }
+      end
+      if available 'cfn-lint' then
+        lint.linters_by_ft.cfn = { 'cfn_lint' }
+      end
 
       -- Detect CloudFormation templates (Emacs cfn-yaml-mode / cfn-json-mode)
       vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
@@ -45,9 +67,11 @@ return {
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
         callback = function()
-          if vim.bo.modifiable then
-            lint.try_lint()
+          if not vim.bo.modifiable then
+            return
           end
+          -- Never let a missing linter binary abort the autocmd chain
+          pcall(lint.try_lint)
         end,
       })
     end,

--- a/editors/nvim/lua/kickstart/plugins/lspconfig.lua
+++ b/editors/nvim/lua/kickstart/plugins/lspconfig.lua
@@ -92,6 +92,10 @@ return {
           --  To jump back, press <C-t>.
           map('grd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
 
+          -- Emacs lsp-mode evil-leader maps
+          map('<leader>jd', require('telescope.builtin').lsp_definitions, '[J]ump to [D]efinition')
+          map('<leader>fu', require('telescope.builtin').lsp_references, '[F]ind [U]sages')
+
           -- WARN: This is not Goto Definition, this is Goto Declaration.
           --  For example, in C this would take you to the header.
           map('grD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
@@ -208,32 +212,25 @@ return {
       --  - settings (table): Override the default settings passed when initializing the server.
       --        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
       local servers = {
-        -- clangd = {},
-        -- gopls = {},
-        -- pyright = {},
-        -- rust_analyzer = {},
-        -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
-        --
-        -- Some languages (like typescript) have entire language plugins that can be useful:
-        --    https://github.com/pmizio/typescript-tools.nvim
-        --
-        -- But for many setups, the LSP (`ts_ls`) will work just fine
-
-        -- Auto-configure LSP servers based on treesitter languages
-        clangd = {},           -- C/C++
-        gopls = {},            -- Go
-        pyright = {},          -- Python
-        rust_analyzer = {},    -- Rust
-        ts_ls = {},            -- TypeScript/JavaScript
-
-        -- Additional language servers
-        bashls = {},           -- Bash
-        html = {},             -- HTML
-        cssls = {},            -- CSS
-        jsonls = {},           -- JSON
-        yamlls = {},          -- YAML
-        dockerls = {},        -- Docker
-        eslint = {},           -- ESLint (JavaScript/TypeScript linting)
+        -- Languages covered in Emacs lsp-mode / language sections
+        clangd = {}, -- C/C++
+        gopls = {}, -- Go
+        pyright = {}, -- Python (Emacs still has elpy; pyright is the nvim path)
+        rust_analyzer = {}, -- Rust
+        ts_ls = {}, -- TypeScript/JavaScript
+        bashls = {}, -- Bash / shell
+        html = {}, -- HTML / templates
+        cssls = {}, -- CSS
+        jsonls = {}, -- JSON
+        yamlls = {}, -- YAML
+        dockerls = {}, -- Dockerfile
+        eslint = {}, -- ESLint
+        ruby_lsp = {}, -- Ruby (Emacs solargraph; ruby_lsp is the modern default)
+        clojure_lsp = {}, -- Clojure
+        jdtls = {}, -- Java (Emacs lsp-java)
+        elixirls = {}, -- Elixir
+        terraformls = {}, -- Terraform
+        graphql = {}, -- GraphQL
 
         lua_ls = {
           settings = {
@@ -241,8 +238,6 @@ return {
               completion = {
                 callSnippet = 'Replace',
               },
-              -- You can toggle below to ignore Lua_LS's noisy `missing-fields` warnings
-              -- diagnostics = { disable = { 'missing-fields' } },
             },
           },
         },
@@ -263,14 +258,17 @@ return {
       -- for you, so that they are available from within Neovim.
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
-        'stylua', -- Used to format Lua code
-        'typescript-language-server', -- Required for ts_ls (TypeScript/JavaScript)
-        -- Additional tools that complement the LSP servers
-        'prettier', -- JavaScript/TypeScript/HTML/CSS formatter
-        'black', -- Python formatter
-        'isort', -- Python import sorter
-        'shellcheck', -- Shell script linter
-        'eslint_d', -- Faster ESLint daemon
+        'stylua',
+        'typescript-language-server',
+        'prettier',
+        'prettierd',
+        'black',
+        'isort',
+        'shellcheck',
+        'eslint_d',
+        'goimports',
+        'rubocop',
+        'clj-kondo',
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 

--- a/editors/nvim/lua/kickstart/plugins/treesitter.lua
+++ b/editors/nvim/lua/kickstart/plugins/treesitter.lua
@@ -9,9 +9,10 @@ return {
     opts = {
        -- ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
        ensure_installed = {
-          'bash', 'c', 'clojure', 'cpp', 'css', 'diff', 'dockerfile', 'go', 'html',
-          'javascript', 'json', 'lua', 'luadoc', 'markdown', 'markdown_inline',
-          'python', 'query', 'ruby', 'rust', 'typescript', 'vim', 'vimdoc', 'yaml'
+          'bash', 'c', 'clojure', 'cpp', 'css', 'diff', 'dockerfile', 'elixir',
+          'go', 'graphql', 'html', 'java', 'javascript', 'json', 'lua', 'luadoc',
+          'markdown', 'markdown_inline', 'python', 'query', 'ruby', 'rust',
+          'scss', 'terraform', 'tsx', 'typescript', 'vim', 'vimdoc', 'yaml',
         },
        -- Autoinstall languages that are not installed
        auto_install = true,

--- a/editors/nvim/lua/kickstart/plugins/which-key.lua
+++ b/editors/nvim/lua/kickstart/plugins/which-key.lua
@@ -57,13 +57,24 @@ return {
         },
       },
 
-      -- Document existing key chains
+      -- Document existing key chains (Emacs evil-leader flavored)
       spec = {
-        { '<leader>s', group = '[S]earch' },
+        { '<leader>s', group = '[S]earch / [S]ource' },
         { '<leader>w', group = '[W]indow / write' },
         { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
-        { '<leader>n', group = '[N]umbers / neo-tree' },
-        { '<leader>c', group = '[C]omment / cd' },
+        { '<leader>n', group = '[N]otes / [N]umbers / neo-tree' },
+        { '<leader>c', group = '[C]omment / cd / clear' },
+        { '<leader>g', group = '[G]it / [G]rep' },
+        { '<leader>f', group = '[F]ind / [F]lycheck / [F]ormat' },
+        { '<leader>j', group = '[J]ump' },
+        { '<leader>P', group = '[P]ackages (Lazy)' },
+        { '<leader>d', group = '[D]ocs / [D]elete ws' },
+        { '<leader>k', group = '[K]ill buffer / yank' },
+        { '<leader>m', group = '[M]arks / Marked' },
+        { '<leader>si', group = '[S]tring [I]nflection' },
+        { '<leader>o', group = '[O]rg mode' },
+        { '<leader>F', group = '[F]ind file / dired' },
+        { '<leader>l', group = '[L]ine wrap' },
       },
     },
   },

--- a/editors/nvim/lua/lazy-plugins.lua
+++ b/editors/nvim/lua/lazy-plugins.lua
@@ -52,6 +52,13 @@ require('lazy').setup({
   require 'custom.plugins.easymotion',
   require 'custom.plugins.rainbow',
   require 'custom.plugins.repeat',
+  require 'custom.plugins.neogit',
+  require 'custom.plugins.conjure',
+  require 'custom.plugins.rest',
+  require 'custom.plugins.direnv',
+  require 'custom.plugins.orgmode',
+  require 'custom.plugins.string-case',
+  require 'custom.plugins.snippets',
 
   -- The following comments only work if you have downloaded the kickstart repo, not just copy pasted the
   -- init.lua. If you want these files, they are in the repository, so you can just download them and
@@ -63,8 +70,8 @@ require('lazy').setup({
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
   --
   -- require 'kickstart.plugins.debug',
-  -- require 'kickstart.plugins.indent_line',
-  -- require 'kickstart.plugins.lint',
+  require 'kickstart.plugins.indent_line',
+  require 'kickstart.plugins.lint',
   require 'kickstart.plugins.autopairs',
   require 'kickstart.plugins.neo-tree',
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings the Kickstart Neovim config closer to operating like the literate Emacs setup in `editors/emacs-config.org` — same `,` leader muscle memory for language tooling, git, diagnostics, notes, and day-to-day editing.

### Keybinds / workflows (Emacs evil-leader shaped)
- LSP: `,jd` jump definition, `,fu` find usages (keeps Kickstart `gr*` maps)
- Diagnostics (flycheck-shaped): `,fcn` / `,fcp` / `,fcl` / `,fcb`
- Magit-shaped git via **Neogit** + Fugitive: `,gst`, `,gg`, `,gd`, `,gca`, `,gaa`, `,gpu`, …
- Utilities: `,dw`, `,lt`, `,kb`, `,kr`, bookmarks `,ml`/`,ms`/`,md`, packages `,Pl`
- Notes (Deft-shaped): `,nc` / `,np` / `,nw` / `,nf` → `~/notes/{common,personal,work}`
- Jump: EasyMotion `,jl` / `,jw` / `,jc`
- Format buffer moved to `,fb` so `,f*` stays a prefix like Emacs
- Marked: `,Mp` (+ legacy `,m` alias)

### Language / tooling
- Broader Mason LSPs: ruby, clojure, java, elixir, terraform, graphql (+ existing JS/TS/Go/Python/…)
- Conform: prettier, black/isort, goimports, rubocop, terraform_fmt
- nvim-lint enabled: eslint_d, clj-kondo, shellcheck, rubocop, cfn-lint (only when on PATH/Mason)
- **Conjure** for Clojure REPL (CIDER-shaped `,eb` / `,ef` / `,ri`)
- **kulala** for `.http` restclient parity
- direnv.vim (when `direnv` on PATH), orgmode (basic), text-case, friendly-snippets / Emacs snipmate dirs
- indent-blankline enabled; treesitter langs expanded (tsx, java, elixir, …)

### Docs
- `editors/nvim/EMACS-PARITY.md` maps Emacs → Neovim, known gaps, and optional trims

### Testing (final sweep)
Headless Neovim 0.12, isolated `XDG_*`:
- **128/128** combined registration + behavioral checks passed
- Startup smoke: `STARTUP_OK`
- Lua syntax check: all modules OK
- Covered: leader maps, Neogit/Diffview/Fugitive (incl. `,gaa` staging), text-case cycle, `,cp`, diagnostics, notes/kulala/org/conjure, lint safety, EasyMotion, `,fb`, LuaSnip, macOS guards, `,gf`/`,q`/`,qq` coexistence

### Scope note for review
Ready for human review as-is. Optional trims only if you want thinner: orgmode, kulala, jdtls/elixirls, text-case (`EMACS-PARITY.md`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47a029c8-20c1-4ce1-9996-4bacba7e3d43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47a029c8-20c1-4ce1-9996-4bacba7e3d43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

